### PR TITLE
`basics.h`: fix build error 

### DIFF
--- a/include/basics.h
+++ b/include/basics.h
@@ -10,7 +10,7 @@
 #include <Arduino.h>
 #include <SPI.h>
 #include <ArduinoOTA.h> 
-#include <ArduinoJSON.h>
+#include <ArduinoJson.h>
 #include <muTimer.h>
 
 


### PR DESCRIPTION
This pr fixes a build failure where the header `AndroidJSON.h` is missing.
It seems like the header is not fully capitalized anymore, which this pr fixes.
